### PR TITLE
Fix MarkDown (GFM) syntax, typos and English expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,247 +1,218 @@
-<img width="1440" alt="Screenshot 2019-04-16 at 13 35 20" src="https://user-images.githubusercontent.com/4315469/56206516-dfcc4d00-604c-11e9-855e-b8bb903341bb.png">
+<img width="1440" alt="We are nextmoov and this is how we work." src="https://user-images.githubusercontent.com/4315469/56206516-dfcc4d00-604c-11e9-855e-b8bb903341bb.png">
 
 # What's this?
 
-This is our DNA. This is who we are.\
+This is our DNA. This is who we are.
+
 But, wait, who are we, actually?
 
-**[nextmoov](https://nextmoov.be) is a Belgian Digital Agency. 🇧🇪**\
+**[nextmoov](https://nextmoov.be) is a Belgian Digital Agency. 🇧🇪**
+
 We are in a quest to re-invent the way we work, as true digital nomads, while producing some nice apps, website and chatbots.
 
-On April 16th 2019, we decided to go one step further with our open-minded DNA : go fully open source with it.
+On April 16th 2019, we decided to go one step further with our open-minded DNA: go fully open source with it.
 
-In this repository, you can: 
+In this repository, you can find the following items:
 
-- DNA (this document) : Discover our DNA and suggest any edit to it
-- [Docs/Developers](./developers) : Read some of our internal training documents & conventions for Developers
-- [Issues](https://github.com/nextmoov/nextmoov/issues) : See all the next big steps for us as a company (and the debates around it), from picking a 3D printer to revolutionize our DX.
+- DNA (this document): Discover our DNA and suggest any edit to it;
+- [Docs/Developers](./developers): Read some of our internal training documents & conventions for Developers;
+- [Issues](https://github.com/nextmoov/nextmoov/issues): See all the next big steps for us as a company (and the debates around it), from picking a 3D printer to revolutionize our DX.
 
-
-
-> ### Edits are strongly encouraged
-> Do wish to make any update to this document? \
-> Go ahead! Just make your edit and open a pull request! \
-> And yes, even from you, that guy we never met, living on the other face of the globe!
+> ## Edits are strongly encouraged
 >
-> Not comfortable with PR & Git? Just reach to any member of the Core Team on Slack! \
+> Do you wish to make any update to this document? \
+> Go ahead! Just make your edit and open a pull request! \
+> And yes, even from you, that guy we never met, living on the other side of the globe! \
+> Not comfortable with PR & Git? Just reach to any member of the Core Team on Slack! \
 > [Edit this document →](https://github.com/nextmoov/nextmoov/edit/master/README.md)
-
 
 # Our DNA.
 
-### We are in a quest to redefine work
+## We are in a quest to redefine work
 
-We're trying to reinvent the way a team works together. And we mean it. We leave it to you to read all resulting principles below but _SPOILER_ alert: it involves working whenever and wherever you see fit and you might fall in love with it.
+We're trying to reinvent the way a team works together. And we mean it. We leave it to you to read all resulting principles below but *SPOILER* alert: it involves working whenever and wherever you see fit and you might fall in love with it.
 
-### We are rooted in the mobility of tomorrow 
+## We are rooted in the mobility of tomorrow
 
 You may already know that: our founders don't have their driving license, and nextmoov was built on top of NextRide. We use public transit and alternative transports every day, so the experience is as real as it can get. Our roots are in the mobility sector but our future lies in digital nomadism.
 
-
-### Our projects must be meaningful, groundbreaking & outstanding
+## Our projects must be meaningful, groundbreaking & outstanding
 
 We can be quite picky when it comes to selecting the projects we jump in. \
 Not so much because we are so popular we can afford to be so. But rather because we believe we work best when we are passionate about something and our clients are too.
 
-
 # Our principles.
 
+## Efficiency at the ❤️ of our work
 
-### Efficiency at the ❤️ of our work
+A lot of people judge their work by the quantity instead of the quality. We don't. We aim to work as smart as possible and be as efficient as possible. We hate losing time, in commute, in useless meetings, in endless boring 9-to-5 weekdays.
 
-A lot of people judge their work by the quantity instead of the quality. We don't. We aim to work as smart as possible and be as efficient as possible. We hate losing time, in commute, in useless meetings, in endless boring 9-to-5 weekdays. \
 Our goal: creating the most efficient teams in the world.
 
-
-### Rigorous methodology
+## Rigorous methodology
 
 We believe we can produce our best work, by working smarter (and actually less). But that ambitious goal comes at a cost: we all must follow the rules of a rigorous methodology. And we're rather uncompromising on those.
 
+## We don't care how, but your work should be fantastic
 
-### We don't care how, but your work should be fantastic
+We don't care *when* you work. We don't care *where* you work. We only care that the work is done perfectly and in time.
 
-We don't care _when_ you work. We don't care _where_ you work. We only care that the work is done perfectly and in time. That means no shift, no timesheet, no mandatory presence. If you want to work during the night, good for you! We're not all made the same. Your work just better be amazing, no matter what.
+That means no shift, no timesheet, no mandatory presence. If you want to work during the night, good for you! We're not all made the same. Your work just better be amazing, no matter what.
 
+## Move your ass
 
-### Move your ass
+Babysitting is not our thing. If you're in doubt, don't sit still wondering what you should do. We won't bite you (as far as I remember, it hasn't happened *yet*). Anyway, if you have a question, you should fire away. We'll reply as soon as we have a minute.
 
-Babysitting is not our thing. If you're in doubt, don't sit still wondering what you should do. We won't bite you (as far as I remember, it hasn't happened _yet_). Anyway, if you have a question, you should fire away. We'll reply as soon as we have a minute.
+## Work on your own
 
+We believe you make the best of your work when you concentrate (no shit!). That's why we work alone. No shoulder tap interruptions, but convenient collaboration (see [Collaboration](#collaborating) below).
 
-### Work on your own
+## Plan together
 
-We believe you make the best of your work when you concentrate (no shit!). That's why we work alone. No shoulder tap interruptions, but convenient collaboration (see Collaboration below).
+But we also believe constructive criticism helps to shape better products. We must show our work to others on a regular basis. At the very least during a weekly review, but not only.
 
-
-### Plan together
-
-But we also believe constructive criticism helps to shape betters products. We must show our work to others on a regular basis. At the very least during a weekly review, but not only. 
-
-
-### Report often
+## Report often
 
 We don't work in the same room, and we don't appreciate unplanned interruptions. That's why we must all continuously and automatically report progress on our part of the job.
 
+## The 15 percent rule
 
-### The 15 percent rule
+Developing top-notch products is great but requires to stay ahead of the pack at all times. And that means taking the time to experiment, combine, tweak... all the new cool things available out there. Hence we decided to allocate 15% of our work time to just that: have fun building what may turn out to be our next big thing.
 
-Developing top-notch products is great but requires to stay ahead of the pack at all times. And that means taking the time to experiment, combine, tweak ... all the new cool things available out there. Hence we decided to allocate 15% of our work time to just that: have fun building what may turn out to be our next big thing.
+## Conventions over configurations
 
+We love stealing concepts from our developers to use them in our daily lives.
 
-### Conventions over configurations
+One of our favorites: "conventions over configurations". Conventions everywhere calms down our OCD, but also helps us save hours and hours of work.
 
-We love stealing concepts from our developers to use them in our daily lives. \
-One of our favorites: "conventions over configurations". Conventions everywhere calm down our OCD, but also help us save hours and hours of work.  \
-Naming folders, picking a slack channel, writing a subject line: conventions help us automate all these hundreds of decisions we take everyday. \
-Keeping everything nice and tidy — automagically!
+Naming folders, picking a Slack channel, writing a subject line: conventions help us automate all these hundreds of decisions we take everyday.
 
-### Simplicity
+Keeping everything nice and tidy - automagically!
 
-Yet another rule we stole from our developers: Keep It Stupid Simple (KISS). \
-We always aim to simplify things. But hey, take note of that one: quite often, the simplest solution is far from the easiest. The simplest solution might be to stop working with a client we don't have a match with, refuses complicated but well paying project, stop working with a team member who don't fit in.  \
+## Simplicity
+
+Yet another rule we stole from our developers: Keep It Stupid Simple (KISS).
+
+We always aim to simplify things. But hey, take note of that one: quite often, the simplest solution is far from the easiest. The simplest solution might be to stop working with a client we don't have a match with, refuse complicated but well paying project, stop working with a team member who don't fit in.
+
 Hard decisions, but simple one: they allow us to stay who we are.
 
+## Use the best tool
 
-### Use the best tool
+As you will see in the Guidelines, we have strong conventions over what tools we use. Slack, GitHub, Drive: all these tools are like the hammer of... well, whatever profession uses a hammer. By using *creme de la creme* tools, we stop doing repetitive dumbass tasks and concentrate on what distinguishes us from stupid bots: building unique things.
 
-As you will see in the Guidelines, we have strong conventions over what tools we use. Slack, GitHub, Drive: all these tools are like the hammer of… well, whatever profession uses a hammer. By using _creme de la creme _tools, we stop doing repetitive dumbass tasks and concentrate on what distinguishes us from stupid bots: building unique things.
-
-
-### Openness
+## Openness
 
 Freelancers have access to core data about the company. The only reason not to disclose documents are the ones that are of a legal type. Income? Turnover? Plans? We start by sharing everything with the team, instead of the other way round.
 
+## Paperless
 
-### Paperless
-
-We are a digital studio. Like… digital. We print almost nothing and keep everything in the cloud.
+We are a digital studio. Like... digital. We print almost nothing and keep everything in the cloud.
 
 Let's build a better future. GO TREES! 🌳
 
-
-### Come as you are
+## Come as you are
 
 Unless we have a meeting with a partner or client, we really (like reaaaally) don't care how you're dressed. Leave mandatory suits to boring companies. And in the case of a meeting, you should still avoid suits but use a casual smart or casual business dress code.
 
+## The α and the Ω
 
-### The α and the Ω
-
-We build our products in an agile way, meaning we deliver regularly so as to ensure the perfect fit with our client's needs. That also means every release should build on top the previous and bring added value. Which in turns involves a lot (a lot ( a lot ( a lot))) of testing. As we're all in the same boat, we expect we all participate to it. So allow some free space to welcome Alpha and Beta apps in your busy phone. And use them.
-
+We build our products in an agile way, meaning we deliver regularly so as to ensure the perfect fit with our client's needs. That also means every release should build on top the previous and bring added value. Which in turn involves a lot (a lot (a lot (a lot))) of testing. As we're all in the same boat, we expect we all participate to it. So allow some free space to welcome Alpha and Beta apps in your busy phone. And use them.
 
 # Collaborating.
 
-### Non Remote Fridays & Workshop
+## Non Remote Fridays & Workshop
 
 We really wanted to have Casual Fridays, but then we realized we are not wearing a suit any day of the week...
-That's why we created the.... (drum roll)... **Non Remote Fridays**.
+That's why we created the... (drum roll)... **Non Remote Fridays**.
 
 It's the day of the week to gather round @ Brussels HQ for anyone willing to.
+
 We run the Sprint Debrief, a quickly WeeklyBrief, share a lunch and then discover a new exciting tech during the workshop.
 
-#### Sprint Debrief — Every Friday, 10:00
+### Sprint Debrief - Every Friday, 10:00
 
-During the weekly (half—)Sprint Debrief, you will be reviewing your assigned Stories with your Project Manager, and according to the project progress, you will be briefed for the upcoming week. 
+During the weekly (half-)Sprint Debrief, you will be reviewing your assigned Stories with your Project Manager, and according to the project progress, you will be briefed for the upcoming week. 
 
-10:00, remember that time : every stories of yours needs to be completed by that time.
-Cause, you know : deadline are one of the rare thing we don't laugh about. 🤷🏽‍♀️
+10:00, remember that time: every stories of yours needs to be completed by that time.
 
+Cause, you know: deadline are one of the rare thing we don't laugh about. 🤷🏽‍♀️
 
-#### WeeklyBrief — Every Friday, 11:30
+### WeeklyBrief - Every Friday, 11:30
 
-Every Friday, the Core Team meet and do a quick checkup of every project being actively developed, as well as update the main milestones for the Company. Everyone is welcomed to attend! 
+Every Friday, the Core Team meet and do a quick checkup of every project being actively developed, as well as update the main milestones for the Company. Everyone is welcome to attend! 
 
-#### Workshop — Every Friday, 14:00
+### Workshop - Every Friday, 14:00
 
-Kubernetes, FramerX, 3D Printing, React Native : We play with a lot of tech.\
+Kubernetes, FramerX, 3D Printing, React Native: We play with a lot of tech.
+
 Want to discover a new one? We all do! 
 
-Everyone can attend : (former) team members, (former) interns, friends, friends of friends, and, of course, your mom.
-**The agenda is publicly available:**
+Everyone can attend: (former) team members, (former) interns, friends, friends of friends, and, of course, your mom. **The agenda is publicly available:**
 - [iCal](https://calendar.google.com/calendar/ical/nextmoov.be_ajkj8t9pv1gbiov7r4n4mfq52s%40group.calendar.google.com/public/basic.ics)
 - [Online View](https://calendar.google.com/calendar/embed?src=nextmoov.be_ajkj8t9pv1gbiov7r4n4mfq52s%40group.calendar.google.com&ctz=Europe%2FBrussels)
 
-### Constant reporting — 24/7
+## Constant reporting - 24/7
 
 Everyone should constantly report progress on the appropriate Zube project base and push their code on GitHub. And the automatic integration to Slack will do the trick.
 
-
 # Writing.
-
 
 ## General guidelines
 
 First and foremost, nextmoov is written nextmoov. Forget "NextMoov", "Nextmoov", and don't even try "NextMove" or adding a space in the middle: the Creative Director might be slightly upset 🤷🏼‍♂️
 
-
 ### English only, but the customer is king
 
-All internals documents should be written in English. But beware that documents made for clients should be written communication in the  language chosen by the client in the Client OnBoarding Process.
+All internals documents should be written in English. But beware that documents made for clients should be written communication in the language chosen by the client in the Client OnBoarding Process.
 
-For internal communication, such as Slack or e-mails, feel free to speak French or English.
-
+For internal communication, such as Slack or emails, feel free to speak French or English.
 
 ## Documents
 
-
 ### Use Google Drive
 
-Unless you reaaaaally need THAT very specific function from Excel, always use Google Drive. Collaboration will be way more easier for everyone — don't we all hate playing boomerang with Something-V29-ModifsThomas-ReluParMathieu-CheckFrancois-FINAL.docx by e-mail?
-
+Unless you reaaaaally need THAT very specific function from Excel, always use Google Drive. Collaboration will be way easier for everyone - don't we all hate playing boomerang with Something-V29-ModifsThomas-ReluParMathieu-CheckFrancois-FINAL.docx by email?
 
 ### Use styles
 
-Structure your Google Docs documents using Title 1, Title 2, ... instead of manually picking font size. That will allow you to do things like changing all the titles all at once, or generate a nice index.
-
+Structure your Google Docs documents using styles like Title 1, Title 2,... instead of doing direct formatting (manually picking font size, font weight,...). This will allow you to do things like changing all the titles at once or generate a nice index.
 
 ### Use templates
 
 It's pretty self-explanatory. We hate losing time, so we simplify tasks. You can find some basic templates in your Drive.
 
-
-## E-mails
-
+## Emails
 
 ### Follow our subject line convention
 
-Following a simple convention when writing the subject line of an e-mail can help both the client and us save a lot of time when searching for a specific e-mail. It also helps us to build some automated reports.
-
-
+Following a simple convention when writing the subject line of an email can help both the client and us save a lot of time when searching for a specific email. It also helps us to build some automated reports.
 ```
-nextmoov/<CLIENT_ID> - Project - Specific subject of e-mail
+nextmoov/<CLIENT_ID> - Project - Specific subject of email
 ```
 
-
-Example :
-
-
+Example:
 ```
 nextmoov/Cambio - Discover&Register - Payment
 ```
 
+### Answer all emails in less than 24 hours
 
+If you need more than 24 hours to answer an email, you must let the client know by sending a quick email saying so. Being available to our clients is a cornerstone of our reputation.
 
-### Answer all e-mails in less than 24 hours
+### Follow-up with the client if she doesn't answer email
 
-If you need more than 24 hours to answer an e-mail, you must let the client know by sending a quick e-mail saying so. Being available to our clients is a cornerstone of our reputation.
+If you sent an email between Monday and Wednesday, send a friendly reminder on Monday. If you sent an email between Tuesday and Sunday, send a friendly reminder on Wednesday.
 
-
-### Follow-up with the client if she doesn't answer e-mail
-
-If you sent an e-mail between Monday and Wednesday, send a friendly reminder on Monday. If you sent an e-mail between Tuesday and Sunday, send a friendly reminder on Wednesday.
-
-You must avoid sending "complex" e-mails on Friday after 11.00AM.** **And last but not least, you must use our corporate signature.
-
+You must avoid sending "complex" emails on Friday after 11.00AM. And last but not least, you must use our corporate signature.
 
 ### Systematically cc the appropriate Slack channel
 
-We've been through this already, Slack is our all-in-one communication hub and you should therefore cc the channel e-mail address so we make sure everyone has access to the freshest information at all time.
-
+We've been through this already, Slack is our all-in-one communication hub and you should therefore cc the channel email address so we make sure everyone has access to the freshest information at all time.
 
 # Tools.
 
-
-### Our all-rounders' daily companions
+## Our all-rounders' daily companions
 
 You know the best teams out there all have their legendary tools, right? Think of Frodo's ring, Harry's wand or Superman's underwear 💥
 
@@ -249,9 +220,9 @@ Likewise, at nextmoov, we have some wonderful tools to fuel our collaboration. P
 
 Zube is a Project Management layer that comes on top of GitHub and allows for some fancy PM-stuff while staying perfectly synchronized. 
 
-Airtable is a shared database where we store everything from contacts details to inventory of assets. We use it as a kind of CRM to say it otherwise.
+Airtable is a shared database where we store everything from contacts details to inventory of assets. We use it as a kind of CRM to say it in other words.
 
-Slack is our all-in-one internal communication tool. This is the place where the teamwork happens, from sharing news to raising questions to your colleagues. Its power comes from its tight integration with all our other tools (Zube, Airtable, Drive, Mail, GitHub …) making it the perfect hub to stay up-to-date. Also, this is where we make jokes most of the time :)
+Slack is our all-in-one internal communication tool. This is the place where the teamwork happens, from sharing news to raising questions to your colleagues. Its power comes from its tight integration with all our other tools (Zube, Airtable, Drive, Mail, GitHub...) making it the perfect hub to stay up-to-date. Also, this is where we make jokes most of the time 🙂
 
 Next comes Google Drive, our... well you know Drive right?
 
@@ -259,25 +230,22 @@ Lastly, for the accounts we share among the studio, we use 1Password, our cloudy
 
 And that's it.
 
-… Wait, what about the good ol' mail then? Well, we use it of course, but for external communication only and with some strict writing conventions (see below).
+... Wait, what about the good ol' email then? Well, we use it of course, but for external communication only and with some strict writing conventions (see below).
 
-Before going any further, we should tell you that we're a macOS-oriented agency. This means all our tools run on macOS. Depending on your profile, it might affect you differently (have you ever tried opening a _.key_ file on your windows laptop? 🤪).
+Before going any further, we should tell you that we're a UNIX-friendly agency. This means all our tools run either on macOS or GNU/Linux. Depending on your profile, it might affect you differently (have you ever tried opening a *.key* file on your Windows laptop? 🤪).
 
-### For Developers
+## For Developers
 
 Lucky you! Our developers have their own dedicated On Boarding Guide! 🤘
 
 We are strong believers of the "Conventions over Configuration" paradigm.
 
-Good news : this shitload of conventions is going to make your life as developer a pure heaven. 80% of the architectural decision have been taken for you already — just focus on writing neat code. 
+Good news: this shitload of conventions is going to make your life as developer a pure heaven. 80% of the architectural decision have been taken for you already - just focus on writing neat code.
 
+## For designers
 
-### For designers
-
-Well there's nothing as fancy as secret keys and stuff for you. But you're part of the best team in nextmoov 👑 — disclaimer: parts of this guide were written by the Creative Director. With Sketch App, you should be all set. And that's it. Photoshop is also accepted, but discouraged for UI design.
+Well there's nothing as fancy as secret keys and stuff for you. But you're part of the best team in nextmoov 👑 - disclaimer: parts of this guide were written by the Creative Director. With Sketch App, you should be all set. And that's it. Photoshop is also accepted, but discouraged for UI design.
 
 Other design tools such as Framer X are still being considered but haven't been thoroughly tested yet.
 
-It seems logical, but we remind you that as a freelance designer, you should own your own legal copies of the softwares you use.
-
-
+It seems logical, but we remind you that as a freelance designer, you have to own your own genuine legal versions of the pieces of software you use.


### PR DESCRIPTION
Some corrections of mine:

* Accessibility for blind/terminal only people
* Avoid GitHub Flavored Markdown like `_` underscores to have italic text or unneeded `\` when a simple line break is enough. Doesn't render properly in console/text editor other than VSCode.
* Respect title hierarchy (the Creative Director might not like the changes :D)
* Use `email` instead of `e-mail` ([the latter is rarely used](https://trends.google.com/trends/explore?q=email,e-mail)).
* Don't add a space before `:`, `!`, `?` in English. Narrow non breaking space is for French (see [1](https://github.com/wget/mattermost-localization-french-translation-rules#points-%C3%A0-am%C3%A9liorer) and [2](http://malizor.org/public/fines/fines.pdf)) :)
* Use ASCII when possible (`...` and `-`)
* Some typos/English expressions (welcome/pieces of)
* UNIX-friendly instead macOS-oriented. nextmoov is open, not elitist :)

Idea of improvement: add links to other (sub-)guides when these have been proofread.