### PR TITLE
fix(CheckupMeeting): Remove limited fields

### DIFF
--- a/onboarding/CheckupMeeting.md
+++ b/onboarding/CheckupMeeting.md
@@ -36,7 +36,7 @@ Let's discuss frankly together and see what we can improve!
 ### Projects & Technologies
 
 - How do you feel regarding the projects you are working on?
-- How senior are you regarding the field you're in ? (back, front, design)
+- How senior are you regarding the field you're in ?
 - How much progress did you make since the latest evaluation?
 - What are the next things you want to learn?
 


### PR DESCRIPTION
In the question “how senior do you feel”, we no longer mention fields (design, frontend, backend) to avoid missing some (sales, PM,...)